### PR TITLE
PYC-group-report-timeout-patch

### DIFF
--- a/pycaiso/oasis.py
+++ b/pycaiso/oasis.py
@@ -46,9 +46,9 @@ class OASISGroupReport(Enum):
 
 
 class Oasis:
-    def __init__(self, timeout: int = 15) -> None:
-        self.base_url: str = "http://oasis.caiso.com/oasisapi/SingleZip?"
-        self.group_url: str = "http://oasis.caiso.com/oasisapi/GroupZip?"
+    def __init__(self, timeout=(10, 120)) -> None:
+        self.base_url: str = "https://oasis.caiso.com/oasisapi/SingleZip?"
+        self.group_url: str = "https://oasis.caiso.com/oasisapi/GroupZip?"
         self.timeout: int = timeout
 
     @staticmethod


### PR DESCRIPTION
+ minimal patch to Oasis class to correct timeout issue for get_daily_dam_lmps() (and all GroupReport requests):
    + the 15-sec read timeout was too tight for the big daily zips returned by GroupReport requests to consistently download, so it has been increased to something a bit more forgiving
    + now using https directly for endpoints (avoids the unnecessary 302 hop)
